### PR TITLE
Add files to discourage submissions of PRs to the GitHub mirror.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+## Contributing to GCC
+
+Thanks for taking the time to contribute to GCC! Please be advised that if you are
+viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
+The GCC community does not use `github.com` for their contributions. Instead, we use
+a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code
+reviews, and bug reports.
+
+Perhaps one day it will be possible to use [GitGitGadget](https://gitgitgadget.github.io/) to
+conveniently send Pull Requests commits to GCC's mailing list, the way that the Git project currently allows it to be used to send PRs to their mailing list, but until that day arrives, please send your patches to the mailing list manually.
+
+Please read ["Contributing to GCC"](https://gcc.gnu.org/contribute.html) on the main GCC website
+to learn how the GCC project is managed, and how you can work with it.
+In addition, we highly recommend you to read [our guidelines for read-write Git access](https://gcc.gnu.org/gitwrite.html).
+
+Or, you can follow the ["Contributing to GCC in 10 easy steps"](https://gcc.gnu.org/wiki/GettingStarted#Basics:_Contributing_to_GCC_in_10_easy_steps) section of the ["Getting Started" page](https://gcc.gnu.org/wiki/GettingStarted) on [the wiki](https://gcc.gnu.org/wiki) for another example of the contribution process.
+
+Your friendly GCC community!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Thanks for taking the time to contribute to GCC! Please be advised that if you are
+viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
+The GCC community does not use `github.com` for their contributions. Instead, we use
+a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
+bug reports. Please send patches there instead.


### PR DESCRIPTION
Local version of: https://gcc.gnu.org/pipermail/gcc-patches/2023-October/633191.html

ChangeLog:

	* .github/CONTRIBUTING.md: New file.
	* .github/PULL_REQUEST_TEMPLATE.md: New file.