### PR TITLE
Fix code scanning alert #32: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/net/netip/netip.go
+++ b/libgo/go/net/netip/netip.go
@@ -1259,7 +1259,7 @@ const invalidPrefixBits = -1
 // If bits is less than zero or greater than ip.BitLen, Prefix.Bits
 // will return an invalid value -1.
 func PrefixFrom(ip Addr, bits int) Prefix {
-	if bits < 0 || bits > ip.BitLen() {
+	if bits < 0 || bits > ip.BitLen() || bits < math.MinInt16 || bits > math.MaxInt16 {
 		bits = invalidPrefixBits
 	}
 	b16 := int16(bits)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/32](https://github.com/cooljeanius/gcc/security/code-scanning/32)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
