### PR TITLE
Fix code scanning alert #29: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/net/http/pprof/pprof.go
+++ b/libgo/go/net/http/pprof/pprof.go
@@ -202,6 +202,10 @@ func Symbol(w http.ResponseWriter, r *http.Request) {
 		}
 		pc, _ := strconv.ParseUint(string(word), 0, 64)
 		if pc != 0 {
+			if pc > ^uint64(0)>>1 {
+				fmt.Fprintf(&buf, "address out of range: %v\n", pc)
+				continue
+			}
 			f := runtime.FuncForPC(uintptr(pc))
 			if f != nil {
 				fmt.Fprintf(&buf, "%#x %s\n", pc, f.Name())


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/29](https://github.com/cooljeanius/gcc/security/code-scanning/29)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
