### PR TITLE
Fix code scanning alert #28: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/internal/fuzz/mutator.go
+++ b/libgo/go/internal/fuzz/mutator.go
@@ -179,6 +179,9 @@ func (m *mutator) mutateUInt(v, maxValue uint64) uint64 {
 			if max > math.MaxInt32 {
 				max = math.MaxInt32
 			}
+			if max > uint64(math.MaxInt) {
+				max = uint64(math.MaxInt)
+			}
 			v += uint64(1 + m.rand(int(max)))
 			return v
 		case 1:
@@ -192,6 +195,9 @@ func (m *mutator) mutateUInt(v, maxValue uint64) uint64 {
 			}
 			if max > math.MaxInt32 {
 				max = math.MaxInt32
+			}
+			if max > uint64(math.MaxInt) {
+				max = uint64(math.MaxInt)
 			}
 			v -= uint64(1 + m.rand(int(max)))
 			return v


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/28](https://github.com/cooljeanius/gcc/security/code-scanning/28)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
