### PR TITLE
Fix code scanning alert #27: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/internal/fuzz/encoding.go
+++ b/libgo/go/internal/fuzz/encoding.go
@@ -341,16 +341,40 @@ func parseUint(val, typ string) (any, error) {
 	switch typ {
 	case "uint":
 		i, err := strconv.ParseUint(val, 0, 64)
-		return uint(i), err
+		if err != nil {
+			return 0, err
+		}
+		if i > math.MaxUint {
+			return 0, fmt.Errorf("value %d overflows uint", i)
+		}
+		return uint(i), nil
 	case "uint8", "byte":
 		i, err := strconv.ParseUint(val, 0, 8)
-		return uint8(i), err
+		if err != nil {
+			return 0, err
+		}
+		if i > math.MaxUint8 {
+			return 0, fmt.Errorf("value %d overflows uint8", i)
+		}
+		return uint8(i), nil
 	case "uint16":
 		i, err := strconv.ParseUint(val, 0, 16)
-		return uint16(i), err
+		if err != nil {
+			return 0, err
+		}
+		if i > math.MaxUint16 {
+			return 0, fmt.Errorf("value %d overflows uint16", i)
+		}
+		return uint16(i), nil
 	case "uint32":
 		i, err := strconv.ParseUint(val, 0, 32)
-		return uint32(i), err
+		if err != nil {
+			return 0, err
+		}
+		if i > math.MaxUint32 {
+			return 0, fmt.Errorf("value %d overflows uint32", i)
+		}
+		return uint32(i), nil
 	case "uint64":
 		return strconv.ParseUint(val, 0, 64)
 	default:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/27](https://github.com/cooljeanius/gcc/security/code-scanning/27)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
