### PR TITLE
Fix code scanning alert #35: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/libgo/go/golang.org/x/mod/zip/zip.go
+++ b/libgo/go/golang.org/x/mod/zip/zip.go
@@ -776,7 +776,7 @@ func Unzip(dir string, m module.Version, zipFile string) (err error) {
 	}
 	for _, zf := range z.File {
 		name := zf.Name[len(prefix):]
-		if name == "" || strings.HasSuffix(name, "/") {
+		if name == "" || strings.HasSuffix(name, "/") || strings.Contains(name, "..") {
 			continue
 		}
 		dst := filepath.Join(dir, name)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/35](https://github.com/cooljeanius/gcc/security/code-scanning/35)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
