### PR TITLE
Fix code scanning alert #23: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/go/scanner/scanner.go
+++ b/libgo/go/go/scanner/scanner.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"unicode"
 	"unicode/utf8"
+	"math"
 )
 
 // An ErrorHandler may be provided to Scanner.Init. If a syntax error is
@@ -296,8 +297,11 @@ func trailingDigits(text []byte) (int, int, bool) {
 		return 0, 0, false // no ":"
 	}
 	// i >= 0
-	n, err := strconv.ParseUint(string(text[i+1:]), 10, 0)
-	return i + 1, int(n), err == nil
+	n, err := strconv.ParseUint(string(text[i+1:]), 10, 32)
+	if err != nil || n > math.MaxInt32 {
+		return 0, 0, false
+	}
+	return i + 1, int(n), true
 }
 
 func (s *Scanner) findLineEnd() bool {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/23](https://github.com/cooljeanius/gcc/security/code-scanning/23)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
