### PR TITLE
Fix code scanning alert #22: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -996,6 +996,7 @@ func (s *ss) scanOne(verb rune, arg any) {
 		i := s.scanUint(verb, uintptrBits)
 		if i > math.MaxUintptr {
 			s.errorString("unsigned integer overflow on token " + strconv.FormatUint(i, 10))
+			return
 		}
 		*v = uintptr(i)
 	// Floats are tricky because you want to scan in the precision of the result, not

--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -993,7 +993,11 @@ func (s *ss) scanOne(verb rune, arg any) {
 	case *uint64:
 		*v = s.scanUint(verb, 64)
 	case *uintptr:
-		*v = uintptr(s.scanUint(verb, uintptrBits))
+		i := s.scanUint(verb, uintptrBits)
+		if i > math.MaxUintptr {
+			s.errorString("unsigned integer overflow on token " + strconv.FormatUint(i, 10))
+		}
+		*v = uintptr(i)
 	// Floats are tricky because you want to scan in the precision of the result, not
 	// scan in high precision and convert, in order to preserve the correct error condition.
 	case *float32:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/22](https://github.com/cooljeanius/gcc/security/code-scanning/22)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
