### PR TITLE
Fix code scanning alert #20: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -987,7 +987,13 @@ func (s *ss) scanOne(verb rune, arg any) {
 	case *uint8:
 		*v = uint8(s.scanUint(verb, 8))
 	case *uint16:
-		*v = uint16(s.scanUint(verb, 16))
+		{
+			val := s.scanUint(verb, 16)
+			if val > math.MaxUint16 {
+				s.errorString("unsigned integer overflow on token " + strconv.FormatUint(val, 10))
+			}
+			*v = uint16(val)
+		}
 	case *uint32:
 		*v = uint32(s.scanUint(verb, 32))
 	case *uint64:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/20](https://github.com/cooljeanius/gcc/security/code-scanning/20)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
