### PR TITLE
Fix code scanning alert no. 21: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -995,7 +995,13 @@ func (s *ss) scanOne(verb rune, arg any) {
 			*v = uint16(val)
 		}
 	case *uint32:
-		*v = uint32(s.scanUint(verb, 32))
+		{
+			val := s.scanUint(verb, 32)
+			if val > math.MaxUint32 {
+				s.errorString("unsigned integer overflow on token " + strconv.FormatUint(val, 10))
+			}
+			*v = uint32(val)
+		}
 	case *uint64:
 		*v = s.scanUint(verb, 64)
 	case *uintptr:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/21](https://github.com/cooljeanius/gcc/security/code-scanning/21)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
