### PR TITLE
Fix code scanning alert no. 39: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -985,7 +985,13 @@ func (s *ss) scanOne(verb rune, arg any) {
 	case *uint:
 		*v = uint(s.scanUint(verb, intBits))
 	case *uint8:
-		*v = uint8(s.scanUint(verb, 8))
+		{
+			val := s.scanUint(verb, 8)
+			if val > math.MaxUint8 {
+				s.errorString("unsigned integer overflow on token " + strconv.FormatUint(val, 10))
+			}
+			*v = uint8(val)
+		}
 	case *uint16:
 		{
 			val := s.scanUint(verb, 16)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/39](https://github.com/cooljeanius/gcc/security/code-scanning/39)

To fix the problem, we need to add an upper bound check before converting the parsed `uint64` value to `uint8`. This ensures that the value is within the acceptable range for `uint8` (0 to 255). If the value exceeds this range, we should handle the error appropriately, such as by returning a default value or raising an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
