### PR TITLE
Fix code scanning alert no. 42: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -983,7 +983,13 @@ func (s *ss) scanOne(verb rune, arg any) {
 	case *int64:
 		*v = s.scanInt(verb, 64)
 	case *uint:
-		*v = uint(s.scanUint(verb, intBits))
+		{
+			val := s.scanUint(verb, intBits)
+			if val > math.MaxUint {
+				s.errorString("unsigned integer overflow on token " + strconv.FormatUint(val, 10))
+			}
+			*v = uint(val)
+		}
 	case *uint8:
 		{
 			val := s.scanUint(verb, 8)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/42](https://github.com/cooljeanius/gcc/security/code-scanning/42)

To fix the problem, we need to ensure that the conversion from `uint64` to `uint` includes an upper bound check to prevent overflow. Specifically, we should check if the parsed value exceeds the maximum value that can be held by the `uint` type before performing the conversion.

1. Add an upper bound check for the `uint` type before converting the parsed value.
2. Use the `math.MaxUint` constant to compare the parsed value against the maximum allowable value for the `uint` type.
3. If the parsed value exceeds the maximum value, handle the error appropriately (e.g., by returning a default value or raising an error).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
