### PR TITLE
Fix code scanning alert no. 43: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -658,10 +658,16 @@ func (s *ss) scanInt(verb rune, bitSize int) int64 {
 	if err != nil {
 		s.error(err)
 	}
-	n := uint(bitSize)
-	x := (i << (64 - n)) >> (64 - n)
-	if x != i {
-		s.errorString("integer overflow on token " + tok)
+	if bitSize == 32 {
+		if i < math.MinInt32 || i > math.MaxInt32 {
+			s.errorString("integer overflow on token " + tok)
+		}
+	} else {
+		n := uint(bitSize)
+		x := (i << (64 - n)) >> (64 - n)
+		if x != i {
+			s.errorString("integer overflow on token " + tok)
+		}
 	}
 	return i
 }
@@ -688,10 +694,16 @@ func (s *ss) scanUint(verb rune, bitSize int) uint64 {
 	if err != nil {
 		s.error(err)
 	}
-	n := uint(bitSize)
-	x := (i << (64 - n)) >> (64 - n)
-	if x != i {
-		s.errorString("unsigned integer overflow on token " + tok)
+	if bitSize == 32 {
+		if i > math.MaxUint32 {
+			s.errorString("unsigned integer overflow on token " + tok)
+		}
+	} else {
+		n := uint(bitSize)
+		x := (i << (64 - n)) >> (64 - n)
+		if x != i {
+			s.errorString("unsigned integer overflow on token " + tok)
+		}
 	}
 	return i
 }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/43](https://github.com/cooljeanius/gcc/security/code-scanning/43)

To fix the problem, we need to ensure that the parsed integer value fits within the bounds of the target type before performing the conversion. This can be done by adding explicit checks for the minimum and maximum values of the target type. If the value is out of bounds, an appropriate error should be raised.

For `int32`, the bounds are `math.MinInt32` and `math.MaxInt32`. We will add these checks in the `scanInt` function before returning the value. Similarly, for other integer types, we will add the corresponding bounds checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
