### PR TITLE
Fix code scanning alert no. 22: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -1029,7 +1029,11 @@ func (s *ss) scanOne(verb rune, arg any) {
 	case *uint64:
 		*v = s.scanUint(verb, 64)
 	case *uintptr:
-		*v = uintptr(s.scanUint(verb, uintptrBits))
+		val := s.scanUint(verb, uintptrBits)
+		if val > (1<<uintptrBits - 1) {
+			s.errorString("unsigned integer overflow on token " + strconv.FormatUint(val, 10))
+		}
+		*v = uintptr(val)
 	// Floats are tricky because you want to scan in the precision of the result, not
 	// scan in high precision and convert, in order to preserve the correct error condition.
 	case *float32:

--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -698,6 +698,10 @@ func (s *ss) scanUint(verb rune, bitSize int) uint64 {
 		if i > math.MaxUint32 {
 			s.errorString("unsigned integer overflow on token " + tok)
 		}
+	} else if bitSize == uintptrBits {
+		if i > (1<<uintptrBits - 1) {
+			s.errorString("unsigned integer overflow on token " + tok)
+		}
 	} else {
 		n := uint(bitSize)
 		x := (i << (64 - n)) >> (64 - n)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/22](https://github.com/cooljeanius/gcc/security/code-scanning/22)

To fix the problem, we need to ensure that the value parsed by `strconv.ParseUint` does not exceed the maximum value that can be represented by `uintptr` before performing the conversion. This can be done by adding an upper bound check for the `uintptr` type, similar to the checks already present for `uint16` and `uint32`.

1. Determine the maximum value for `uintptr` based on the system's architecture.
2. Add a check to ensure the parsed value does not exceed this maximum value.
3. If the value is within bounds, proceed with the conversion; otherwise, handle the overflow error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
