### PR TITLE
Fix code scanning alert no. 16: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -658,11 +658,20 @@ func (s *ss) scanInt(verb rune, bitSize int) int64 {
 	if err != nil {
 		s.error(err)
 	}
-	if bitSize == 32 {
+	switch bitSize {
+	case 8:
+		if i < math.MinInt8 || i > math.MaxInt8 {
+			s.errorString("integer overflow on token " + tok)
+		}
+	case 16:
+		if i < math.MinInt16 || i > math.MaxInt16 {
+			s.errorString("integer overflow on token " + tok)
+		}
+	case 32:
 		if i < math.MinInt32 || i > math.MaxInt32 {
 			s.errorString("integer overflow on token " + tok)
 		}
-	} else {
+	default:
 		n := uint(bitSize)
 		x := (i << (64 - n)) >> (64 - n)
 		if x != i {
@@ -694,11 +703,20 @@ func (s *ss) scanUint(verb rune, bitSize int) uint64 {
 	if err != nil {
 		s.error(err)
 	}
-	if bitSize == 32 {
+	switch bitSize {
+	case 8:
+		if i > math.MaxUint8 {
+			s.errorString("unsigned integer overflow on token " + tok)
+		}
+	case 16:
+		if i > math.MaxUint16 {
+			s.errorString("unsigned integer overflow on token " + tok)
+		}
+	case 32:
 		if i > math.MaxUint32 {
 			s.errorString("unsigned integer overflow on token " + tok)
 		}
-	} else {
+	default:
 		n := uint(bitSize)
 		x := (i << (64 - n)) >> (64 - n)
 		if x != i {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/16](https://github.com/cooljeanius/gcc/security/code-scanning/16)

To fix the problem, we need to add explicit bounds checking for each specific integer type before converting the parsed 64-bit integer to a smaller type. This ensures that the value is within the valid range for the target type, preventing overflow and unexpected values.

- For `int16`, check if the parsed value is within the range of `math.MinInt16` to `math.MaxInt16`.
- For `int8`, check if the parsed value is within the range of `math.MinInt8` to `math.MaxInt8`.
- For `int32`, the existing check is sufficient.
- For `uint16`, check if the parsed value is within the range of `0` to `math.MaxUint16`.
- For `uint8`, check if the parsed value is within the range of `0` to `math.MaxUint8`.
- For `uint32`, the existing check is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
