### PR TITLE
Fix code scanning alert no. 43: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/fmt/scan.go
+++ b/libgo/go/fmt/scan.go
@@ -671,6 +671,7 @@ func (s *ss) scanInt(verb rune, bitSize int) int64 {
 		if i < math.MinInt32 || i > math.MaxInt32 {
 			s.errorString("integer overflow on token " + tok)
 		}
+		return int32(i)
 	default:
 		n := uint(bitSize)
 		x := (i << (64 - n)) >> (64 - n)


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/43](https://github.com/cooljeanius/gcc/security/code-scanning/43)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to a smaller integer type (e.g., `int32`) includes proper bounds checking. This can be done by adding a check to ensure that the value of the parsed integer falls within the acceptable range for the target type before performing the conversion.

Specifically, we need to:
1. Add bounds checking for the conversion to `int32` in the `scanInt` function.
2. Ensure that the bounds checking is consistent with the other bit sizes already handled in the function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
