### PR TITLE
Fix code scanning alert no. 13: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/debug/pe/section.go
+++ b/libgo/go/debug/pe/section.go
@@ -32,9 +32,12 @@ func (sh *SectionHeader32) fullName(st StringTable) (string, error) {
 	if sh.Name[0] != '/' {
 		return cstring(sh.Name[:]), nil
 	}
-	i, err := strconv.Atoi(cstring(sh.Name[1:]))
+	i, err := strconv.ParseInt(cstring(sh.Name[1:]), 10, 32)
 	if err != nil {
 		return "", err
+	}
+	if i < 0 || i > math.MaxUint32 {
+		return "", fmt.Errorf("value out of range for uint32: %d", i)
 	}
 	return st.String(uint32(i))
 }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/13](https://github.com/cooljeanius/gcc/security/code-scanning/13)

To fix the problem, we should replace the use of `strconv.Atoi` with `strconv.ParseInt`, specifying the bit size to match the target type (`uint32`). Additionally, we should add bounds checking to ensure the parsed integer fits within the range of `uint32`.

- Replace `strconv.Atoi` with `strconv.ParseInt` specifying a 32-bit size.
- Add bounds checking to ensure the parsed value is within the range of `uint32`.
- Update the relevant lines in the file `libgo/go/debug/pe/section.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
