### PR TITLE
Fix code scanning alert no. 12: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/archive/tar/strconv.go
+++ b/libgo/go/archive/tar/strconv.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"math"
 )
 
 // hasNUL reports whether the NUL character exists within s.
@@ -169,6 +170,10 @@ func (p *parser) parseOctal(b []byte) int64 {
 	x, perr := strconv.ParseUint(p.parseString(b), 8, 64)
 	if perr != nil {
 		p.err = ErrHeader
+	}
+	if x > math.MaxInt64 {
+		p.err = ErrHeader
+		return 0
 	}
 	return int64(x)
 }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/12](https://github.com/cooljeanius/gcc/security/code-scanning/12)

To fix the problem, we need to ensure that the value parsed from the string fits within the bounds of `int64` before converting it. This can be done by checking if the parsed `uint64` value is within the range of `int64` and handling cases where it is not.

1. Parse the string using `strconv.ParseUint` as before.
2. Check if the parsed value is within the bounds of `int64`.
3. If the value is within bounds, convert it to `int64`.
4. If the value is out of bounds, handle the error appropriately (e.g., set an error flag or return a default value).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
