### PR TITLE
Fix code scanning alert no. 11: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/archive/tar/reader.go
+++ b/libgo/go/archive/tar/reader.go
@@ -262,10 +262,18 @@ func mergePAX(hdr *Header, paxHdrs map[string]string) (err error) {
 			hdr.Gname = v
 		case paxUid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Uid = int(id64) // Integer overflow possible
+			if err == nil && id64 >= int64(math.MinInt) && id64 <= int64(math.MaxInt) {
+				hdr.Uid = int(id64)
+			} else {
+				return ErrHeader
+			}
 		case paxGid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Gid = int(id64) // Integer overflow possible
+			if err == nil && id64 >= int64(math.MinInt) && id64 <= int64(math.MaxInt) {
+				hdr.Gid = int(id64)
+			} else {
+				return ErrHeader
+			}
 		case paxAtime:
 			hdr.AccessTime, err = parsePAXTime(v)
 		case paxMtime:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/11](https://github.com/cooljeanius/gcc/security/code-scanning/11)

To fix the problem, we need to ensure that the values parsed from the string are within the bounds of the `int` type before performing the conversion. This can be done by checking if the parsed `int64` value is within the range of the `int` type. If the value is out of bounds, we should handle the error appropriately.

The best way to fix this issue is to:
1. Parse the integer value using `strconv.ParseInt` with a bit size of 64.
2. Check if the parsed value is within the bounds of the `int` type.
3. Only convert the value to `int` if it is within the bounds; otherwise, handle the error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
