### PR TITLE
Fix code scanning alert no. 45: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/archive/tar/reader.go
+++ b/libgo/go/archive/tar/reader.go
@@ -370,8 +370,20 @@ func (tr *Reader) readHeader() (*Header, *block, error) {
 	hdr.Linkname = p.parseString(v7.linkName())
 	hdr.Size = p.parseNumeric(v7.size())
 	hdr.Mode = p.parseNumeric(v7.mode())
-	hdr.Uid = int(p.parseNumeric(v7.uid()))
-	hdr.Gid = int(p.parseNumeric(v7.gid()))
+	{
+		uid := p.parseNumeric(v7.uid())
+		if uid < math.MinInt32 || uid > math.MaxInt32 {
+			return nil, nil, ErrHeader // or handle the error appropriately
+		}
+		hdr.Uid = int(uid)
+	}
+	{
+		gid := p.parseNumeric(v7.gid())
+		if gid < math.MinInt32 || gid > math.MaxInt32 {
+			return nil, nil, ErrHeader // or handle the error appropriately
+		}
+		hdr.Gid = int(gid)
+	}
 	hdr.ModTime = time.Unix(p.parseNumeric(v7.modTime()), 0)
 
 	// Unpack format specific fields.

--- a/libgo/go/archive/tar/strconv.go
+++ b/libgo/go/archive/tar/strconv.go
@@ -175,6 +175,10 @@ func (p *parser) parseOctal(b []byte) int64 {
 		p.err = ErrHeader
 		return 0
 	}
+	if x > uint64(math.MaxInt32) {
+		p.err = ErrHeader
+		return 0
+	}
 	return int64(x)
 }
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/45](https://github.com/cooljeanius/gcc/security/code-scanning/45)

To fix the problem, we need to ensure that the value parsed from the string is within the bounds of a 32-bit signed integer before converting it. This can be done by adding a check to ensure the parsed value does not exceed `math.MaxInt32` and is not less than `math.MinInt32`. If the value is out of bounds, we should handle it appropriately, either by returning a default value or by raising an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
