### PR TITLE
Fix code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/libgo/go/archive/tar/reader.go
+++ b/libgo/go/archive/tar/reader.go
@@ -262,14 +262,14 @@ func mergePAX(hdr *Header, paxHdrs map[string]string) (err error) {
 		case paxGname:
 			hdr.Gname = v
 		case paxUid:
-			id64, err = strconv.ParseInt(v, 10, 64)
-			if id64 < int64(math.MinInt) || id64 > int64(math.MaxInt) {
+			id64, err = strconv.ParseInt(v, 10, 32)
+			if id64 < int64(math.MinInt32) || id64 > int64(math.MaxInt32) {
 				return ErrHeader // Handle overflow error
 			}
 			hdr.Uid = int(id64)
 		case paxGid:
-			id64, err = strconv.ParseInt(v, 10, 64)
-			if id64 < int64(math.MinInt) || id64 > int64(math.MaxInt) {
+			id64, err = strconv.ParseInt(v, 10, 32)
+			if id64 < int64(math.MinInt32) || id64 > int64(math.MaxInt32) {
 				return ErrHeader // Handle overflow error
 			}
 			hdr.Gid = int(id64)

--- a/libgo/go/archive/tar/reader.go
+++ b/libgo/go/archive/tar/reader.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"math"
 )
 
 // Reader provides sequential access to the contents of a tar archive.
@@ -262,10 +263,16 @@ func mergePAX(hdr *Header, paxHdrs map[string]string) (err error) {
 			hdr.Gname = v
 		case paxUid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Uid = int(id64) // Integer overflow possible
+			if id64 < int64(math.MinInt) || id64 > int64(math.MaxInt) {
+				return ErrHeader // Handle overflow error
+			}
+			hdr.Uid = int(id64)
 		case paxGid:
 			id64, err = strconv.ParseInt(v, 10, 64)
-			hdr.Gid = int(id64) // Integer overflow possible
+			if id64 < int64(math.MinInt) || id64 > int64(math.MaxInt) {
+				return ErrHeader // Handle overflow error
+			}
+			hdr.Gid = int(id64)
 		case paxAtime:
 			hdr.AccessTime, err = parsePAXTime(v)
 		case paxMtime:


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/10](https://github.com/cooljeanius/gcc/security/code-scanning/10)

To fix the problem, we need to ensure that the conversion from `int64` to `int` does not result in overflow. This can be achieved by checking that the parsed value is within the bounds of the `int` type before performing the conversion. If the value is out of bounds, we should handle the error appropriately.

The best way to fix this is to:
1. Parse the integer using `strconv.ParseInt` with a bit size of 64.
2. Check if the parsed value is within the bounds of the `int` type.
3. Only perform the conversion if the value is within bounds; otherwise, handle the error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
