### PR TITLE
Fix code scanning alert no. 7: Size computation for allocation may overflow

### DIFF
--- a/libgo/go/fmt/format.go
+++ b/libgo/go/fmt/format.go
@@ -70,7 +70,7 @@ func (f *fmt) writePadding(n int) {
 	newLen := oldLen + n
 	// Make enough room for padding.
 	if newLen > cap(buf) {
-		if n > (cap(buf)*2 - oldLen) {
+		if n > (cap(buf)*2 - oldLen) || n > (1<<31-1) {
 			// Handle the error appropriately, e.g., log an error or return early.
 			return
 		}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/7](https://github.com/cooljeanius/gcc/security/code-scanning/7)

To fix the overflow issue, we need to add a more robust check to ensure that the value of `n` will not cause an overflow when used in the allocation. Specifically, we should check that `n` is within a safe range before performing the allocation. If `n` is too large, we should handle the error appropriately, such as by logging an error or returning early.

**Steps to fix:**
1. Add a check to ensure that `n` is within a safe range before performing the allocation.
2. If `n` is too large, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
