### PR TITLE
Fix code scanning alert no. 7: Size computation for allocation may overflow

### DIFF
--- a/libgo/go/fmt/format.go
+++ b/libgo/go/fmt/format.go
@@ -70,7 +70,7 @@ func (f *fmt) writePadding(n int) {
 	newLen := oldLen + n
 	// Make enough room for padding.
 	if newLen > cap(buf) {
-		if n > (cap(buf)*2 - oldLen) || n > (1<<31-1) {
+		if n > (cap(buf)*2 - oldLen) || n > (1<<31-1) || newLen < oldLen {
 			// Handle the error appropriately, e.g., log an error or return early.
 			return
 		}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/7](https://github.com/cooljeanius/gcc/security/code-scanning/7)

To fix the problem, we need to ensure that the size computation for allocation does not overflow. This can be achieved by adding a more robust guard condition to check for potential overflow before performing the allocation. Specifically, we should check if `n` is within a safe range before using it in the allocation calculation.

1. **General Fix:** Validate the size of `n` to ensure it does not cause an overflow when used in the allocation calculation.
2. **Detailed Fix:** Add a check to ensure that `n` is within a safe range before performing the allocation. If `n` is too large, handle the error appropriately.
3. **Specific Changes:** Modify the `writePadding` function in `libgo/go/fmt/format.go` to include the additional guard condition.
4. **Requirements:** No new imports or definitions are needed. The changes will be confined to the `writePadding` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
