### PR TITLE
Fix code scanning alert no. 7: Size computation for allocation may overflow

### DIFF
--- a/libgo/go/fmt/format.go
+++ b/libgo/go/fmt/format.go
@@ -70,7 +70,7 @@ func (f *fmt) writePadding(n int) {
 	newLen := oldLen + n
 	// Make enough room for padding.
 	if newLen > cap(buf) {
-		if n > (cap(buf)*2 - oldLen) || n > (1<<31-1) || newLen < oldLen {
+		if n > (cap(buf)*2 - oldLen) || n > (1<<31-1) || newLen < oldLen || newLen > (1<<31-1) {
 			// Handle the error appropriately, e.g., log an error or return early.
 			return
 		}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gcc/security/code-scanning/7](https://github.com/cooljeanius/gcc/security/code-scanning/7)

To fix the problem, we need to ensure that the size computation for allocation does not overflow. This can be achieved by adding more comprehensive checks before performing the allocation. Specifically, we should validate the size of `n` and ensure that the addition of `n` to `oldLen` does not overflow.

1. Add a check to ensure that `n` is within a safe range before performing the addition.
2. Validate that the result of the addition (`newLen`) does not overflow.
3. If any of these checks fail, handle the error appropriately by logging an error or returning early.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
