### PR TITLE
Potential fix for code scanning alert no. 56: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linux-go.yaml
+++ b/.github/workflows/linux-go.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.name }}-build-go


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/gcc/security/code-scanning/56](https://github.com/cooljeanius/gcc/security/code-scanning/56)

Add an explicit `permissions` block in `.github/workflows/linux-go.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden. The minimal least-privilege fix for this workflow is:

- `contents: read`

This preserves existing behavior for checkout/build/test/artifact upload while constraining token access. No imports, methods, or dependencies are needed (YAML-only change).  
Best edit location: directly after the `concurrency` block and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
