### PR TITLE
Potential fix for code scanning alert no. 55: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.name }}-build


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/gcc/security/code-scanning/55](https://github.com/cooljeanius/gcc/security/code-scanning/55)

Add an explicit `permissions` block to `.github/workflows/linux.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden. The minimal safe baseline for this workflow is:

- `contents: read`

This preserves existing functionality while documenting and enforcing least privilege for `GITHUB_TOKEN`.  
Edit region: after the `concurrency` block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
