### PR TITLE
Potential fix for code scanning alert no. 57: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/libgo/go/crypto/x509/pem_decrypt.go
+++ b/libgo/go/crypto/x509/pem_decrypt.go
@@ -79,6 +79,11 @@ var rfc1423Algos = []rfc1423Algo{{
 // deriveKey uses a key derivation function to stretch the password into a key
 // with the number of bits our cipher requires. This algorithm was derived from
 // the OpenSSL source.
+//
+// NOTE: This is legacy-compatible RFC 1423/OpenSSL key derivation, which uses
+// MD5 and is cryptographically weak for password-based key derivation. It is
+// retained only for interoperability with existing encrypted PEM blocks.
+// New applications should use stronger formats/KDFs.
 func (c rfc1423Algo) deriveKey(password, salt []byte) []byte {
 	hash := md5.New()
 	out := make([]byte, c.keySize)


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/gcc/security/code-scanning/57](https://github.com/cooljeanius/gcc/security/code-scanning/57)

General fix: avoid using MD5-based password derivation for sensitive data. Use a modern password KDF (PBKDF2/scrypt/Argon2) with per-item random salt and adequate work factor for new encryption operations; keep legacy logic only for backward-compatible decryption paths.

Best practical fix in this file while preserving existing behavior of legacy RFC 1423 handling is to **isolate and clearly mark** the MD5 derivation as legacy-compatibility-only and avoid extending its usage. A full cryptographic migration (new PEM encryption scheme) requires changes beyond the shown snippet/API contract, so no safe in-snippet replacement can be done without breaking compatibility with existing PEM blocks.

Specific region: `libgo/go/crypto/x509/pem_decrypt.go`, the `deriveKey` method (lines ~82–96) and its MD5 use/import.  
Needed for full remediation (outside this snippet’s safe scope): new KDF implementation (e.g., PBKDF2-HMAC-SHA256), format/version markers in PEM headers, and encrypt/decrypt branching for new-vs-legacy scheme.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
